### PR TITLE
wrap topbar into a block and remove it from errors page

### DIFF
--- a/templates/error.html.twig
+++ b/templates/error.html.twig
@@ -1,5 +1,6 @@
 {% extends 'partials/base.html.twig' %}
 
+{% block topbar %}{% endblock %}
 {% block navigation %}{% endblock %}
 
 {% block content %}

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -61,7 +61,7 @@
         <div class="padding highlightable">
             <a href="#" id="sidebar-toggle" data-sidebar-toggle><i class="fa fa-2x fa-bars"></i></a>
 
-            {% if theme_config.github.position == 'top' or config.plugins.breadcrumbs.enabled %}
+            {% block topbar %}{% if theme_config.github.position == 'top' or config.plugins.breadcrumbs.enabled %}
             <div id="top-bar">
                 {% if theme_config.github.position == 'top' %}
                 <div id="top-github-link">
@@ -73,7 +73,7 @@
                 {% include 'partials/breadcrumbs.html.twig' %}
                 {% endif %}
             </div>
-            {% endif %}
+            {% endif %}{% endblock %}
 
             {% block content %}{% endblock %}
 


### PR DESCRIPTION
This way the top bar can be removed from error or any other page that should not render it.