### PR TITLE
Update with keyboard prev/next control

### DIFF
--- a/js/learn.js
+++ b/js/learn.js
@@ -207,6 +207,28 @@ jQuery(document).ready(function() {
             });
         }
     });
+    
+    // allow keyboard control for prev/next links
+    jQuery(function() {
+        jQuery('.nav-prev').click(function(){
+            location.href = jQuery(this).attr('href');
+        });
+        jQuery('.nav-next').click(function() {
+            location.href = jQuery(this).attr('href');
+        });
+    });
+
+    jQuery(document).keydown(function(e) {
+      // prev links - left arrow key
+      if(e.which == '37') {
+        jQuery('.nav.nav-prev').click();
+      }
+
+      // next links - right arrow key
+      if(e.which == '39') {
+        jQuery('.nav.nav-next').click();
+      }
+    });     
 
 });
 


### PR DESCRIPTION
Based on issue #174 (https://github.com/getgrav/grav-learn/issues/174) and my own itch to use the left/right arrow key to go through the pages I added a little jQuery snippet to handle the prev/next keyboard navigation.