### PR TITLE
Add in default.html.twig file for error on Grav 1.0.10

### DIFF
--- a/templates/default.html.twig
+++ b/templates/default.html.twig
@@ -1,0 +1,6 @@
+{% extends 'partials/base.html.twig' %}
+
+{% block content %}
+	{{ page.content }}
+{% endblock %}
+


### PR DESCRIPTION
Fix for issue #19 where the missing default.html.twig file isn't available for Grav 1.0.10.