### PR TITLE
Removed duplicate 'github.commits' field and re-titled 'github.commit…

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -57,10 +57,5 @@ form:
 
     github.commits:
         type: text
-        label: GitHub Tree
-        default: https://github.com/getgrav/grav-skeleton-rtfm-site/commits/develop/
-
-    github.commits:
-        type: text
-        label: GitHub Tree
+        label: GitHub Commits
         default: https://github.com/getgrav/grav-skeleton-rtfm-site/commits/develop/


### PR DESCRIPTION
…s' to 'GitHub Commits'.

BTW, I notice that 'github.commits' do not seem to be currently used anywhere (please confirm). If this is the case perhaps it can be removed entirely to make config a bit more straightforward for users?

Thanks,
Paul