### PR TITLE
Render bottom group js assets in base template

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -91,5 +91,8 @@
         {% include 'partials/analytics.html.twig' %}
         {% endif %}
     {% endblock %}
+    {% block bottom %}
+        {{ assets.js('bottom') }}
+    {% endblock %}
  </body>
 </html>


### PR DESCRIPTION
Fix as mentioned in https://github.com/getgrav/grav-theme-learn2/issues/62