### PR TITLE
Remove tab characters from comment indent

### DIFF
--- a/learn2.yaml
+++ b/learn2.yaml
@@ -1,5 +1,5 @@
 enabled: true
-root_page: 					                        # optional: set root page of documentation
+root_page:                                          # optional: set root page of documentation
 top_level_version: false                            # Use versions for top level navigation
 show_all_pages: false                               # Show all pages without having to 'open' them
 google_analytics_code:                              # Enter your `UA-XXXXXXXX-X` code here


### PR DESCRIPTION
Indent the comment with spaces instead of tabs as on some systems the tab characters prevent the theme from being loaded.

Related issue: https://github.com/getgrav/grav-theme-learn2/issues/90
Also see the learn2-git-sync theme that has the same issue: https://github.com/hibbitts-design/grav-theme-learn2-git-sync/pull/16