### PR TITLE
Adapts language variable names to current naming convention (plus typos)

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -1,48 +1,56 @@
 en:
-    THEME_LEARN2_GITHUB_EDIT_THIS_PAGE: edit this page
-    THEME_LEARN2_GITHUB_NOTE: Found errors? Think you can improve this documentation?
-    THEME_LEARN2_CLEAR_HISTORY: Clear History
-    THEME_LEARN2_BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
-    THEME_LEARN2_SEARCH_DOCUMENTATION: Search Documentation
+  THEME_LEARN2:
+    GITHUB_EDIT_THIS_PAGE: edit this page
+    GITHUB_NOTE: Found errors? Think you can improve this documentation?
+    CLEAR_HISTORY: Clear history
+    BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
+    SEARCH_DOCUMENTATION: Search documentation
 cn:
-    THEME_LEARN2_GITHUB_EDIT_THIS_PAGE: 编辑此页
-    THEME_LEARN2_GITHUB_NOTE: 发现错误？请帮忙改进，谢谢！
-    THEME_LEARN2_CLEAR_HISTORY: 清除历史
-    THEME_LEARN2_BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
-    THEME_LEARN2_SEARCH_DOCUMENTATION: 搜索文档
+  THEME_LEARN2:
+    GITHUB_EDIT_THIS_PAGE: 编辑此页
+    GITHUB_NOTE: 发现错误？请帮忙改进，谢谢！
+    CLEAR_HISTORY: 清除历史
+    BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
+    SEARCH_DOCUMENTATION: 搜索文档
 cs:
-    THEME_LEARN2_GITHUB_EDIT_THIS_PAGE: Upravte tuto stránku
-    THEME_LEARN2_GITHUB_NOTE: Našli jste chybu? Myslíte, že můžete vylepšit tuto dokumentaci?
-    THEME_LEARN2_CLEAR_HISTORY: Smazat historii
-    THEME_LEARN2_BUILT_WITH_GRAV: Postaveno na <a href="http://getgrav.org">Grav</a> - Moderní správce obsahu pomocí souborů prostých textů
-    THEME_LEARN2_SEARCH_DOCUMENTATION: Vyhledat v dokumentaci
+  THEME_LEARN2:
+    GITHUB_EDIT_THIS_PAGE: Upravte tuto stránku
+    GITHUB_NOTE: Našli jste chybu? Myslíte, že můžete vylepšit tuto dokumentaci?
+    CLEAR_HISTORY: Smazat historii
+    BUILT_WITH_GRAV: Postaveno na <a href="http://getgrav.org">Grav</a> - Moderní správce obsahu pomocí souborů prostých textů
+    SEARCH_DOCUMENTATION: Vyhledat v dokumentaci
 de:
-    THEME_LEARN2_GITHUB_EDIT_THIS_PAGE: diese Seite bearbeiten
-    THEME_LEARN2_GITHUB_NOTE: Fehler gefunden? Möchten Sie diese Seite verbessern?
-    THEME_LEARN2_CLEAR_HISTORY: Verlauf löschen
-    THEME_LEARN2_BUILT_WITH_GRAV: Seite erstellt mit <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
-    THEME_LEARN2_SEARCH_DOCUMENTATION: Dokumentation durchsuchen
+  THEME_LEARN2:
+    GITHUB_EDIT_THIS_PAGE: diese Seite bearbeiten
+    GITHUB_NOTE: Fehler gefunden? Möchten Sie diese Seite verbessern?
+    CLEAR_HISTORY: Verlauf löschen
+    BUILT_WITH_GRAV: Seite erstellt mit <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
+    SEARCH_DOCUMENTATION: Dokumentation durchsuchen
 es:
-    THEME_LEARN2_GITHUB_EDIT_THIS_PAGE: editar esta página
-    THEME_LEARN2_GITHUB_NOTE: ¿Encontraste errores? ¿Crees que puedes mejorar esta documentación?
-    THEME_LEARN2_CLEAR_HISTORY: Limpiar historial
-    THEME_LEARN2_BUILT_WITH_GRAV: Hecho con <a href="http://getgrav.org">Grav</a> - El CMS moderno de archivos planos
-    THEME_LEARN2_SEARCH_DOCUMENTATION: Buscar en la documentación
+  THEME_LEARN2:
+    GITHUB_EDIT_THIS_PAGE: editar esta página
+    GITHUB_NOTE: ¿Encontraste errores? ¿Crees que puedes mejorar esta documentación?
+    CLEAR_HISTORY: Limpiar historial
+    BUILT_WITH_GRAV: Hecho con <a href="http://getgrav.org">Grav</a> - El CMS moderno de archivos planos
+    SEARCH_DOCUMENTATION: Buscar en la documentación
 fr:
-    THEME_LEARN2_GITHUB_EDIT_THIS_PAGE: modifier cette page
-    THEME_LEARN2_GITHUB_NOTE: Vous avez découvert des erreurs ? Vous pensez pouvoir améliorer cette documentation ?
-    THEME_LEARN2_CLEAR_HISTORY: Effacer l'historique
-    THEME_LEARN2_BUILT_WITH_GRAV: Créé avec <a href="http://getgrav.org">Grav</a> - Le CMS moderne sans base de données
-    THEME_LEARN2_SEARCH_DOCUMENTATION: Rechercher dans la documentation
+  THEME_LEARN2:
+    GITHUB_EDIT_THIS_PAGE: modifier cette page
+    GITHUB_NOTE: Vous avez découvert des erreurs ? Vous pensez pouvoir améliorer cette documentation ?
+    CLEAR_HISTORY: Effacer l'historique
+    BUILT_WITH_GRAV: Créé avec <a href="http://getgrav.org">Grav</a> - Le CMS moderne sans base de données
+    SEARCH_DOCUMENTATION: Rechercher dans la documentation
 it:
-    THEME_LEARN2_GITHUB_EDIT_THIS_PAGE: modifica pagina
-    THEME_LEARN2_GITHUB_NOTE: Hai trovato degli errori? Pensi di poter migliorare questa documentazione?
-    THEME_LEARN2_CLEAR_HISTORY: Cancella Cronologia
-    THEME_LEARN2_BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
-    THEME_LEARN2_SEARCH_DOCUMENTATION: Cerca nella Documentatione
+  THEME_LEARN2:
+    GITHUB_EDIT_THIS_PAGE: modifica pagina
+    GITHUB_NOTE: Hai trovato degli errori? Pensi di poter migliorare questa documentazione?
+    CLEAR_HISTORY: Cancella Cronologia
+    BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
+    SEARCH_DOCUMENTATION: Cerca nella documentatione
 ru:
-    THEME_LEARN2_GITHUB_EDIT_THIS_PAGE: редактировать эту страницу
-    THEME_LEARN2_GITHUB_NOTE: Нашли ошибки? Думаете, что можете улучшить документацию?
-    THEME_LEARN2_CLEAR_HISTORY: Очистить историю
-    THEME_LEARN2_BUILT_WITH_GRAV: Сделано на <a href="http://getgrav.org">Grav</a> — современной файловой CMS
-    THEME_LEARN2_SEARCH_DOCUMENTATION: Поиск по документации
+  THEME_LEARN2:
+    GITHUB_EDIT_THIS_PAGE: редактировать эту страницу
+    GITHUB_NOTE: Нашли ошибки? Думаете, что можете улучшить документацию?
+    CLEAR_HISTORY: Очистить историю
+    BUILT_WITH_GRAV: Сделано на <a href="http://getgrav.org">Grav</a> — современной файловой CMS
+    SEARCH_DOCUMENTATION: Поиск по документации

--- a/templates/partials/github_link.html.twig
+++ b/templates/partials/github_link.html.twig
@@ -1,1 +1,1 @@
-<a class="github-link" href="{{ theme_config.github.tree ~  ('/'~page.filePathClean)|replace({'/user/':''}) }}"><i class="fa fa-github-square"></i> {{ 'THEME_LEARN2_GITHUB_EDIT_THIS_PAGE'|t }}</a>
+<a class="github-link" href="{{ theme_config.github.tree ~  ('/'~page.filePathClean)|replace({'/user/':''}) }}"><i class="fa fa-github-square"></i> {{ 'THEME_LEARN2.GITHUB_EDIT_THIS_PAGE'|t }}</a>

--- a/templates/partials/github_note.html.twig
+++ b/templates/partials/github_note.html.twig
@@ -1,6 +1,6 @@
 <blockquote id="github-contrib"><blockquote><blockquote><blockquote><blockquote>
 <p>
-    {{ 'THEME_LEARN2_GITHUB_NOTE'|t }}
+    {{ 'THEME_LEARN2.GITHUB_NOTE'|t }}
 
     {% include 'partials/github_link.html.twig' %}
 </p>

--- a/templates/partials/search.html.twig
+++ b/templates/partials/search.html.twig
@@ -1,6 +1,6 @@
 <div class="searchbox">
     <label for="search-by"><i class="fa fa-search"></i></label>
-    <input id="search-by" type="text" placeholder="{{ 'THEME_LEARN2_SEARCH_DOCUMENTATION'|t }}"
+    <input id="search-by" type="text" placeholder="{{ 'THEME_LEARN2.SEARCH_DOCUMENTATION'|t }}"
            data-search-input="{{ base_url_relative }}/search.json/query"/>
     <span data-search-clear><i class="fa fa-close"></i></span>
 </div>

--- a/templates/partials/sidebar.html.twig
+++ b/templates/partials/sidebar.html.twig
@@ -59,10 +59,10 @@
         <hr />
 
         <a class="padding" href="#" data-clear-history-toggle><i
-                    class="fa fa-fw fa-history"></i> {{ 'THEME_LEARN2_CLEAR_HISTORY'|t }}</a><br/>
+                    class="fa fa-fw fa-history"></i> {{ 'THEME_LEARN2.CLEAR_HISTORY'|t }}</a><br/>
 
         <section id="footer">
-            <p>{{ 'THEME_LEARN2_BUILT_WITH_GRAV'|t|raw }}</p>
+            <p>{{ 'THEME_LEARN2.BUILT_WITH_GRAV'|t|raw }}</p>
         </section>
     </div>
 </div>


### PR DESCRIPTION
Variables names in `languages.yaml` did not follow the [established convention](https://learn.getgrav.org/17/content/multi-language#plugin-and-theme-language-translations). The commit corrects this.