### PR TITLE
Update github_link.html.twig

### DIFF
--- a/templates/partials/github_link.html.twig
+++ b/templates/partials/github_link.html.twig
@@ -1,1 +1,1 @@
-<a class="github-link" href="{{ theme_config.github.tree ~  ('/'~page.filePathClean)|replace({'/user/':''}) }}"><i class="fa fa-github-square"></i> {{ 'THEME_LEARN2_GITHUB_EDIT_THIS_PAGE'|t }}</a>
+<a class="github-link" href="{{ theme_config.github.tree ~ page.filePathClean|regex_replace("/.*(?=\\/pages\\/)/", "") }}"><i class="fa fa-github-square"></i> {{ 'THEME_LEARN2_GITHUB_EDIT_THIS_PAGE'|t }}</a>


### PR DESCRIPTION
If you use the multisite setup, the link is not generated correctly. This commit works in both normal and multisite setup.
#80 