### PR TITLE
Updating for G4A conversion

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -41,7 +41,7 @@ form:
     google_analytics_code:
         type: text
         label: Google Analytics Code
-        placeholder: UA-XXXXXXXX-X
+        placeholder: G-XXXXXXXXXX
         validate:
           type: text
 

--- a/learn2.yaml
+++ b/learn2.yaml
@@ -2,7 +2,7 @@ enabled: true
 root_page:                                          # optional: set root page of documentation
 top_level_version: false                            # Use versions for top level navigation
 show_all_pages: false                               # Show all pages without having to 'open' them
-google_analytics_code:                              # Enter your `UA-XXXXXXXX-X` code here
+google_analytics_code:                              # Enter your `G-XXXXXXXXXX` code here
 home_url:                                           # http://getgrav.org
 github:
     position: top                                   # top | bottom | off

--- a/templates/partials/analytics.html.twig
+++ b/templates/partials/analytics.html.twig
@@ -1,10 +1,8 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ theme_config.google_analytics_code }}"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-  ga('create', '{{ theme_config.google_analytics_code }}', 'auto');
-  ga('send', 'pageview');
-
+  gtag('config', '{{ theme_config.google_analytics_code }}');
 </script>


### PR DESCRIPTION
# Changed:
- Google's Universal Analytics (UA) standard will stop processing data starting on July 1, 2023 in favor for Google Analytics 4 (GA4). This update swaps the UA script to the GA4 script. https://support.google.com/analytics/answer/10089681